### PR TITLE
Add command channel

### DIFF
--- a/rtl/udma_i2c_bus_ctrl.sv
+++ b/rtl/udma_i2c_bus_ctrl.sv
@@ -8,15 +8,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-`define I2C_CMD_NONE  3'b000
-`define I2C_CMD_START 3'b001
-`define I2C_CMD_STOP  3'b010
-`define I2C_CMD_WRITE 3'b011
-`define I2C_CMD_READ  3'b100
-`define I2C_CMD_WAIT  3'b101
-
-
-
+`include "udma_i2c_defines.sv"
 module udma_i2c_bus_ctrl
 (
     input  logic            clk_i,      // system clock
@@ -283,7 +275,7 @@ module udma_i2c_bus_ctrl
         if (sw_rst_i)
           r_cmd_stop <= 1'b0;
         else if (cmd_valid_i)
-          r_cmd_stop <= cmd_i == `I2C_CMD_STOP;
+          r_cmd_stop <= cmd_i == `BUS_CMD_STOP;
       end
 
     always @(posedge clk_i or negedge rstn_i)
@@ -338,11 +330,11 @@ module udma_i2c_bus_ctrl
                       if (cmd_valid_i)
                       begin
                         case (cmd_i) // synopsys full_case parallel_case
-                             `I2C_CMD_START: CS <= S_START_PHASE1;
-                             `I2C_CMD_STOP:  CS <= S_STOP_PHASE1;
-                             `I2C_CMD_WRITE: CS <= S_WR_PHASE1;
-                             `I2C_CMD_READ:  CS <= S_RD_PHASE1;
-                             `I2C_CMD_WAIT:  CS <= S_WAIT_PHASE1;
+                             `BUS_CMD_START: CS <= S_START_PHASE1;
+                             `BUS_CMD_STOP:  CS <= S_STOP_PHASE1;
+                             `BUS_CMD_WRITE: CS <= S_WR_PHASE1;
+                             `BUS_CMD_READ:  CS <= S_RD_PHASE1;
+                             `BUS_CMD_WAIT:  CS <= S_WAIT_PHASE1;
                              default:        CS <= S_IDLE;
                         endcase
                       end

--- a/rtl/udma_i2c_control.sv
+++ b/rtl/udma_i2c_control.sv
@@ -8,24 +8,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-`define I2C_CMD_START   4'h0
-`define I2C_CMD_STOP    4'h2
-`define I2C_CMD_RD_ACK  4'h4
-`define I2C_CMD_RD_NACK 4'h6
-`define I2C_CMD_WR      4'h8
-`define I2C_CMD_WAIT    4'hA
-`define I2C_CMD_RPT     4'hC
-`define I2C_CMD_CFG     4'hE
-`define I2C_CMD_WAIT_EV 4'h1
-
-`define BUS_CMD_NONE  3'b000
-`define BUS_CMD_START 3'b001
-`define BUS_CMD_STOP  3'b010
-`define BUS_CMD_WRITE 3'b011
-`define BUS_CMD_READ  3'b100
-`define BUS_CMD_WAIT  3'b101
-
-
+`include "udma_i2c_defines.sv"
 module udma_i2c_control
 (
 	//

--- a/rtl/udma_i2c_control.sv
+++ b/rtl/udma_i2c_control.sv
@@ -9,6 +9,7 @@
 // specific language governing permissions and limitations under the License.
 
 `include "udma_i2c_defines.sv"
+
 module udma_i2c_control
 (
 	//
@@ -37,7 +38,12 @@ module udma_i2c_control
 	output logic                      scl_oe,
 	input  logic                      sda_i,
 	output logic                      sda_o,
-	output logic                      sda_oe
+	output logic                      sda_oe,
+
+    // CMD channel signals
+    input  logic [31:0] udma_cmd_i,
+    input  logic udma_cmd_valid_i,
+    output logic udma_cmd_ready_o
 );
 
 	//
@@ -49,14 +55,14 @@ module udma_i2c_control
                             ST_CMD_DONE,
                             ST_READ,
                             ST_WRITE,
+                            ST_WRITE_ADDRESS,
                             ST_STORE_DATA,
                             ST_SKIP_CMD,
                             ST_GET_DATA,
                             ST_GET_WAIT,
                             ST_GET_WAIT_EV,
                             ST_GET_RPT,
-                            ST_GET_CFG_MSB,
-                            ST_GET_CFG_LSB
+                            ST_GET_CFG
                         } CS,NS;
 
     logic s_cmd_start;
@@ -64,6 +70,7 @@ module udma_i2c_control
     logic s_cmd_rd_ack;
     logic s_cmd_rd_nack;
     logic s_cmd_wr;
+    logic s_cmd_wra;
     logic s_cmd_wait;
     logic s_cmd_wait_ev;
     logic s_cmd_rpt;
@@ -75,11 +82,17 @@ module udma_i2c_control
     logic s_sample_rpt;
     logic s_sample_ev;
 
+    // store command arguments for direct use (avoid relooping inside FSM
+    // states)
+    logic [24:0] s_cmd_arg;
+    logic [24:0] r_cmd_arg;
+
     logic [15:0] s_div_num;
     logic [15:0] r_div_num;
 
-    logic [6:0] s_rpt_num;
-    logic [6:0] r_rpt_num;
+    // rpt_num is limited by uDMA transfer size (16 bits wide)
+    logic [15:0] s_rpt_num;
+    logic [15:0] r_rpt_num;
 
     logic [7:0] s_data;
     logic [7:0] r_data;
@@ -130,17 +143,20 @@ module udma_i2c_control
 
 	assign s_do_rst    = sw_rst_i;
 
-    assign s_cmd_start   = s_en_decode ? (data_tx_i[7:4] == `I2C_CMD_START)   : 1'b0;
-    assign s_cmd_stop    = s_en_decode ? (data_tx_i[7:4] == `I2C_CMD_STOP)    : 1'b0;
-    assign s_cmd_rd_ack  = s_en_decode ? (data_tx_i[7:4] == `I2C_CMD_RD_ACK)  : 1'b0;
-    assign s_cmd_rd_nack = s_en_decode ? (data_tx_i[7:4] == `I2C_CMD_RD_NACK) : 1'b0;
-    assign s_cmd_wr      = s_en_decode ? (data_tx_i[7:4] == `I2C_CMD_WR)      : 1'b0;
-    assign s_cmd_wait    = s_en_decode ? (data_tx_i[7:4] == `I2C_CMD_WAIT)    : 1'b0;
-    assign s_cmd_wait_ev = s_en_decode ? (data_tx_i[7:4] == `I2C_CMD_WAIT_EV) : 1'b0;
-    assign s_cmd_rpt     = s_en_decode ? (data_tx_i[7:4] == `I2C_CMD_RPT)     : 1'b0;
-    assign s_cmd_cfg     = s_en_decode ? (data_tx_i[7:4] == `I2C_CMD_CFG)     : 1'b0;
+    assign s_cmd_start   = s_en_decode ? (udma_cmd_i[31:28] == `I2C_CMD_START)   : 1'b0;
+    assign s_cmd_stop    = s_en_decode ? (udma_cmd_i[31:28] == `I2C_CMD_STOP)    : 1'b0;
+    assign s_cmd_rd_ack  = s_en_decode ? (udma_cmd_i[31:28] == `I2C_CMD_RD_ACK)  : 1'b0;
+    assign s_cmd_rd_nack = s_en_decode ? (udma_cmd_i[31:28] == `I2C_CMD_RD_NACK) : 1'b0;
+    assign s_cmd_wr      = s_en_decode ? (udma_cmd_i[31:28] == `I2C_CMD_WR)      : 1'b0;
+    assign s_cmd_wra     = s_en_decode ? (udma_cmd_i[31:28] == `I2C_CMD_WRA)     : 1'b0;
+    assign s_cmd_wait    = s_en_decode ? (udma_cmd_i[31:28] == `I2C_CMD_WAIT)    : 1'b0;
+    assign s_cmd_wait_ev = s_en_decode ? (udma_cmd_i[31:28] == `I2C_CMD_WAIT_EV) : 1'b0;
+    assign s_cmd_rpt     = s_en_decode ? (udma_cmd_i[31:28] == `I2C_CMD_RPT)     : 1'b0;
+    assign s_cmd_cfg     = s_en_decode ? (udma_cmd_i[31:28] == `I2C_CMD_CFG)     : 1'b0;
 
-    assign s_ev_sel      = data_tx_i[1:0];
+    assign s_cmd_arg     = s_en_decode ? udma_cmd_i[24:0]                        : 'h0;
+
+    assign s_ev_sel      = udma_cmd_i[25:24];
 
     assign s_core_txd = (CS == ST_READ) ? r_rd_ack : s_data[7];
 
@@ -190,6 +206,7 @@ module udma_i2c_control
 		NS  = CS;
 		s_data_tx_ready     = 1'b0;
 		s_data_rx_valid     = 1'b0;
+		udma_cmd_ready_o    = 1'b0;
 		s_bus_if_cmd        = `BUS_CMD_NONE;
 		s_bus_if_cmd_valid  = 1'b0;
 		s_rd_ack            = r_rd_ack;
@@ -209,7 +226,8 @@ module udma_i2c_control
 				s_en_bus_ctrl   = 1'b0;
 				s_data_tx_ready	= 1'b1;
 				s_en_bus_ctrl   = 1'b1;
-				if (data_tx_valid_i)
+                udma_cmd_ready_o    = 1'b1;
+				if (udma_cmd_valid_i)
 				begin
 					s_en_decode     = 1'b1;
 					if(s_cmd_start)
@@ -235,7 +253,7 @@ module udma_i2c_control
 					end
 					else if(s_cmd_rd_ack)
 					begin
-	        			s_bus_if_cmd       = `BUS_CMD_READ;
+                        s_bus_if_cmd       = `BUS_CMD_READ;
 						s_bus_if_cmd_valid = 1'b1;
 						s_rd_ack = 1'b0;
 						s_bits = 8'h8;
@@ -243,7 +261,7 @@ module udma_i2c_control
 					end
 					else if(s_cmd_rd_nack)
 					begin
-	        			s_bus_if_cmd       = `BUS_CMD_READ;
+                        s_bus_if_cmd       = `BUS_CMD_READ;
 						s_bus_if_cmd_valid = 1'b1;
 						s_rd_ack = 1'b1;
 						s_bits = 8'h8;
@@ -253,13 +271,17 @@ module udma_i2c_control
 					begin
 						NS = ST_GET_DATA;
 					end
+					else if(s_cmd_wra)
+					begin
+                        NS = ST_WRITE_ADDRESS;
+					end
 					else if(s_cmd_rpt)
 					begin
 						NS = ST_GET_RPT;
 					end
 					else if(s_cmd_cfg)
 					begin
-						NS = ST_GET_CFG_MSB;
+						NS = ST_GET_CFG;
 					end
 				end
 			end
@@ -269,7 +291,7 @@ module udma_i2c_control
 					NS = ST_WAIT_IN_CMD;
 				else if (s_cmd_done && !(r_bits == 'h0))
 				begin
-        			s_bus_if_cmd       = `BUS_CMD_WAIT;
+                    s_bus_if_cmd       = `BUS_CMD_WAIT;
 					s_bus_if_cmd_valid = 1'b1;
 					s_bits             = r_bits - 1;
 					NS = ST_CMD_DONE;
@@ -288,7 +310,7 @@ module udma_i2c_control
 			ST_READ:
 				if (s_cmd_done && (r_bits == 'h1))
 				begin
-        			s_bus_if_cmd       = `BUS_CMD_WRITE;
+                    s_bus_if_cmd       = `BUS_CMD_WRITE;
 					s_bus_if_cmd_valid = 1'b1;
 					s_bits = r_bits - 1;
 					s_data = {r_data[6:0],s_core_rxd};
@@ -296,7 +318,7 @@ module udma_i2c_control
 				end
 				else if (s_cmd_done && !(r_bits == 'h0))
 				begin
-        			s_bus_if_cmd       = `BUS_CMD_READ;
+                    s_bus_if_cmd       = `BUS_CMD_READ;
 					s_bus_if_cmd_valid = 1'b1;
 					s_bits = r_bits - 1;
 					s_data = {r_data[6:0],s_core_rxd};
@@ -308,14 +330,14 @@ module udma_i2c_control
 				end
 			ST_STORE_DATA:
 			begin
-				s_data_rx_valid = 1'b1;
+                s_data_rx_valid = 1'b1;
 				if (data_rx_ready_i)
 				begin
 					if(r_rpt_num == 'h0)
 						NS = ST_WAIT_IN_CMD;
 					else
 					begin
-	        			s_bus_if_cmd       = `BUS_CMD_READ;
+                        s_bus_if_cmd       = `BUS_CMD_READ;
 						s_bus_if_cmd_valid = 1'b1;
 						s_bits = 'h8;
 						s_sample_rpt = 1'b1;
@@ -326,15 +348,15 @@ module udma_i2c_control
 			end
 			ST_GET_DATA:
 			begin
-					s_data_tx_ready	= 1'b1;
-					if (data_tx_valid_i)
-					begin
-	        			s_bus_if_cmd       = `BUS_CMD_WRITE;
-						s_bus_if_cmd_valid = 1'b1;
-						s_data = data_tx_i;
-						s_bits = 8'h8;
-						NS = ST_WRITE;
-					end
+                s_data_tx_ready	= 1'b1;
+                if (data_tx_valid_i)
+                begin
+                    s_bus_if_cmd       = `BUS_CMD_WRITE;
+                    s_bus_if_cmd_valid = 1'b1;
+                    s_data = data_tx_i;
+                    s_bits = 8'h8;
+                    NS = ST_WRITE;
+                end
 			end
 			ST_SKIP_CMD:
 			begin
@@ -343,59 +365,38 @@ module udma_i2c_control
 					NS = ST_WAIT_IN_CMD;
 				end
 			end
-			ST_GET_RPT:
-			begin
-					s_data_tx_ready	= 1'b1;
-					if (data_tx_valid_i)
-					begin
-						s_sample_rpt    = 1'b1;
-						if (data_tx_i == 'h0)
-						begin
-							s_rpt_num = 'h0;
-							NS = ST_SKIP_CMD;
-						end
-						else
-						begin
-	        				s_rpt_num       = data_tx_i - 1;
-							NS = ST_WAIT_IN_CMD;
-	        			end
-					end
-			end
-			ST_GET_CFG_MSB:
-			begin
-					s_data_tx_ready	= 1'b1;
-					if (data_tx_valid_i)
-					begin
-						s_sample_div = 1'b1;
-	        			s_div_num[15:8] = data_tx_i;
-						NS = ST_GET_CFG_LSB;
-					end
-			end
-			ST_GET_CFG_LSB:
-			begin
-					s_data_tx_ready	= 1'b1;
-					if (data_tx_valid_i)
-					begin
-						s_sample_div = 1'b1;
-	        			s_div_num[7:0] = data_tx_i;
-						NS = ST_WAIT_IN_CMD;
-					end
-			end
+            ST_GET_RPT:
+            begin
+                s_sample_rpt    = 1'b1;
+                if (r_cmd_arg[7:0] == 'h0)
+                begin
+                    s_rpt_num = 'h0;
+                    NS = ST_SKIP_CMD;
+                end
+                else
+                begin
+                    s_rpt_num = r_cmd_arg[15:0] - 1;
+                    NS = ST_WAIT_IN_CMD;
+                end
+            end
+			ST_GET_CFG:
+            begin
+                s_sample_div = 1'b1;
+                s_div_num[15:0] = r_cmd_arg[15:0];
+                NS = ST_WAIT_IN_CMD;
+            end
 			ST_GET_WAIT:
-			begin
-					s_data_tx_ready	= 1'b1;
-					if (data_tx_valid_i)
-					begin
-	        			s_bus_if_cmd       = `BUS_CMD_WAIT;
-						s_bus_if_cmd_valid = 1'b1;
-						s_bits = data_tx_i;
-						NS = ST_CMD_DONE;
-					end
-			end
+            begin
+                s_bus_if_cmd       = `BUS_CMD_WAIT;
+                s_bus_if_cmd_valid = 1'b1;
+                s_bits = r_cmd_arg[7:0];
+                NS = ST_CMD_DONE;
+            end
 			ST_WRITE:
+            begin
 				if (s_cmd_done && (r_bits == 'h1))
 				begin
-        			s_bus_if_cmd       = `BUS_CMD_READ;
+                    s_bus_if_cmd       = `BUS_CMD_READ;
 					s_bus_if_cmd_valid = 1'b1;
 					s_data = {r_data[6:0],1'b0};
 					s_bits = r_bits - 1;
@@ -403,7 +404,7 @@ module udma_i2c_control
 				end
 				else if (s_cmd_done && !(r_bits == 'h0))
 				begin
-        			s_bus_if_cmd       = `BUS_CMD_WRITE;
+                    s_bus_if_cmd       = `BUS_CMD_WRITE;
 					s_bus_if_cmd_valid = 1'b1;
 					s_data = {r_data[6:0],1'b0};
 					s_bits = r_bits - 1;
@@ -420,6 +421,15 @@ module udma_i2c_control
 				begin
 					NS = ST_WAIT_IN_CMD;
 				end
+            end
+            ST_WRITE_ADDRESS:
+            begin
+                s_bus_if_cmd       = `BUS_CMD_WRITE;
+                s_bus_if_cmd_valid = 1'b1;
+                s_data = r_cmd_arg[7:0];
+                s_bits = 8'h8;
+                NS = ST_WRITE;
+            end
 			default:
 			begin
 				NS  = ST_WAIT_IN_CMD;
@@ -437,9 +447,10 @@ module udma_i2c_control
 	end
 
 	always @(posedge clk_i or negedge rstn_i)
-	  if (!rstn_i)
+      if (!rstn_i)
 	  begin
 	    CS          <= ST_WAIT_IN_CMD;
+        r_cmd_arg   <= 'h0;
 	    r_sample_wd <= 1'b0;
 	    r_rpt_num   <= 'h0;
 	    r_data      <= 'h0;
@@ -455,6 +466,7 @@ module udma_i2c_control
 	  	if (s_do_rst)
 	  	begin
 		    CS          <= ST_WAIT_IN_CMD;
+            r_cmd_arg   <= 'h0;
 		    r_sample_wd <= 1'b0;
 		    r_rpt_num   <= 'h0;
 	    	r_data      <= 'h0;
@@ -468,6 +480,7 @@ module udma_i2c_control
 	  	else
 	  	begin
 		  	CS  <= NS;
+            r_cmd_arg   <= s_cmd_arg;
 		  	r_sample_wd <= s_sample_wd;
 	  		r_data      <= s_data;
 		  	r_bits      <= s_bits;

--- a/rtl/udma_i2c_defines.sv
+++ b/rtl/udma_i2c_defines.sv
@@ -1,0 +1,41 @@
+// I2C Master Registers
+`define REG_RX_SADDR     5'b00000 //BASEADDR+0x00
+`define REG_RX_SIZE      5'b00001 //BASEADDR+0x04
+`define REG_RX_CFG       5'b00010 //BASEADDR+0x08
+`define REG_RX_INTCFG    5'b00011 //BASEADDR+0x0C
+
+`define REG_TX_SADDR     5'b00100 //BASEADDR+0x10
+`define REG_TX_SIZE      5'b00101 //BASEADDR+0x14
+`define REG_TX_CFG       5'b00110 //BASEADDR+0x18
+`define REG_TX_INTCFG    5'b00111 //BASEADDR+0x1C
+
+`define REG_CMD_SADDR    5'b01000 //BASEADDR+0x20
+`define REG_CMD_SIZE     5'b01001 //BASEADDR+0x24
+`define REG_CMD_CFG      5'b01010 //BASEADDR+0x28
+`define REG_CMD_INTCFG   5'b01011 //BASEADDR+0x2C
+
+`define REG_STATUS       5'b01100 //BASEADDR+0x30
+`define REG_SETUP        5'b01101 //BASEADDR+0x34
+
+// uDMA I2C commands
+`define I2C_CMD_START     4'b0000  //              0x0
+`define I2C_CMD_STOP      4'b0010  //              0x2
+`define I2C_CMD_RD_ACK    4'b0100  //              0x4
+`define I2C_CMD_RD_NACK   4'b0110  //              0x6
+`define I2C_CMD_WR        4'b1000  //              0x8
+`define I2C_CMD_WAIT      4'b1010  //              0xA
+`define I2C_CMD_RPT       4'b1100  //              0xC
+`define I2C_CMD_CFG       4'b1110  //              0xE
+`define I2C_CMD_WAIT_EV   4'b0001  //              0x1
+`define I2C_CMD_WRA       4'b0111  //              0x7
+
+// channel selection commands (TX/RX address and enable)
+`define I2C_CMD_SETUP_UCA 4'b0011  // 0x3 --> setup tx/rx address
+`define I2C_CMD_SETUP_UCS 4'b0101  // 0x5 --> stup tx/rx size + enable transfer
+
+`define BUS_CMD_NONE  3'b000
+`define BUS_CMD_START 3'b001
+`define BUS_CMD_STOP  3'b010
+`define BUS_CMD_WRITE 3'b011
+`define BUS_CMD_READ  3'b100
+`define BUS_CMD_WAIT  3'b101

--- a/rtl/udma_i2c_reg_if.sv
+++ b/rtl/udma_i2c_reg_if.sv
@@ -58,12 +58,32 @@ module udma_i2c_reg_if #(
     input  logic [L2_AWIDTH_NOAL-1:0] cfg_tx_curr_addr_i,
     input  logic     [TRANS_SIZE-1:0] cfg_tx_bytes_left_i,
 
+    output logic [L2_AWIDTH_NOAL-1:0] cfg_cmd_startaddr_o,
+    output logic     [TRANS_SIZE-1:0] cfg_cmd_size_o,
+    output logic                      cfg_cmd_continuous_o,
+    output logic                      cfg_cmd_en_o,
+    output logic                      cfg_cmd_clr_o,
+    input  logic                      cfg_cmd_en_i,
+    input  logic                      cfg_cmd_pending_i,
+    input  logic [L2_AWIDTH_NOAL-1:0] cfg_cmd_curr_addr_i,
+    input  logic     [TRANS_SIZE-1:0] cfg_cmd_bytes_left_i,
+
     output logic                      cfg_do_rst_o,
 
     input  logic                      status_busy_i,
-    input  logic                      status_al_i
+    input  logic                      status_al_i,
+
+    input  logic               [31:0] udma_cmd_i,
+    input  logic                      udma_cmd_valid_i,
+    input  logic                      udma_cmd_ready_i
 );
 
+    logic [L2_AWIDTH_NOAL-1:0] r_cmd_startaddr;
+    logic   [TRANS_SIZE-1 : 0] r_cmd_size;
+    logic                      r_cmd_continuous;
+    logic                      r_cmd_en;
+    logic                      r_cmd_clr;
+    
     logic [L2_AWIDTH_NOAL-1:0] r_rx_startaddr;
     logic   [TRANS_SIZE-1 : 0] r_rx_size;
     logic                      r_rx_continuous;
@@ -84,8 +104,31 @@ module udma_i2c_reg_if #(
     logic                      r_al;
     logic                      r_busy;
 
+    //command decode signals
+    logic                 [3:0] s_cmd;
+    logic  [L2_AWIDTH_NOAL-1:0] s_cmd_decode_addr;
+    logic    [TRANS_SIZE-1 : 0] s_cmd_decode_size;
+    logic                       s_cmd_decode_txrxn;
+
+    logic                       s_is_cmd_uca;
+    logic                       s_is_cmd_ucs;
+
+    assign s_cmd              = udma_cmd_i[31:28];
+    assign s_cmd_decode_txrxn = udma_cmd_i[27];
+    assign s_cmd_decode_size  = udma_cmd_i[TRANS_SIZE-1:0];
+    assign s_cmd_decode_addr  = udma_cmd_i[L2_AWIDTH_NOAL-1:0];
+
+    assign s_is_cmd_uca = (s_cmd == `I2C_CMD_SETUP_UCA);
+    assign s_is_cmd_ucs = (s_cmd == `I2C_CMD_SETUP_UCS);
+
     assign s_wr_addr = (cfg_valid_i & ~cfg_rwn_i) ? cfg_addr_i : 5'h0;
     assign s_rd_addr = (cfg_valid_i &  cfg_rwn_i) ? cfg_addr_i : 5'h0;
+
+    assign cfg_cmd_startaddr_o  = r_cmd_startaddr;
+    assign cfg_cmd_size_o       = r_cmd_size;
+    assign cfg_cmd_continuous_o = r_cmd_continuous;
+    assign cfg_cmd_en_o         = r_cmd_en;
+    assign cfg_cmd_clr_o        = r_cmd_clr;
 
     assign cfg_rx_startaddr_o  = r_rx_startaddr;
     assign cfg_rx_size_o       = r_rx_size;
@@ -105,31 +148,70 @@ module udma_i2c_reg_if #(
     begin
         if(~rstn_i)
         begin
-            // SPI REGS
-            r_rx_startaddr  <=  'h0;
-            r_rx_size       <=  'h0;
-            r_rx_continuous <=  'h0;
-            r_rx_en         <=  'h0;
-            r_rx_clr        <=  'h0;
-            r_tx_startaddr  <=  'h0;
-            r_tx_size       <=  'h0;
-            r_tx_continuous <=  'h0;
-            r_tx_en         <=  'h0;
-            r_tx_clr        <=  'h0;
-            r_do_rst        <= 1'b0;
-            r_busy          <= 1'b0;
-            r_al            <= 1'b0;
+            // I2C REGS
+            r_cmd_startaddr  <=  'h0;
+            r_cmd_size       <=  'h0;
+            r_cmd_continuous <=  'h0;
+            r_cmd_en         <=  'h0;
+            r_cmd_clr        <=  'h0;
+            r_rx_startaddr   <=  'h0;
+            r_rx_size        <=  'h0;
+            r_rx_continuous  <=  'h0;
+            r_rx_en          <=  'h0;
+            r_rx_clr         <=  'h0;
+            r_tx_startaddr   <=  'h0;
+            r_tx_size        <=  'h0;
+            r_tx_continuous  <=  'h0;
+            r_tx_en          <=  'h0;
+            r_tx_clr         <=  'h0;
+            r_do_rst         <= 1'b0;
+            r_busy           <= 1'b0;
+            r_al             <= 1'b0;
         end
         else
         begin
-            r_rx_en        <=  'h0;
-            r_rx_clr       <=  'h0;
-            r_tx_en        <=  'h0;
-            r_tx_clr       <=  'h0;
-
-            if (cfg_valid_i & ~cfg_rwn_i)
+            r_rx_en         <=  'h0;
+            r_rx_clr        <=  'h0;
+            r_tx_en         <=  'h0;
+            r_tx_clr        <=  'h0;
+            r_cmd_en        <=  'h0;
+            r_cmd_clr       <=  'h0;
+            if (udma_cmd_valid_i && udma_cmd_ready_i && (s_is_cmd_ucs || s_is_cmd_uca))
+            begin
+                if(s_is_cmd_uca)
+                begin
+                    if(s_cmd_decode_txrxn)
+                        r_tx_startaddr <= s_cmd_decode_addr;
+                    else
+                        r_rx_startaddr <= s_cmd_decode_addr;
+                end
+                else
+                begin
+                    if(s_cmd_decode_txrxn)
+                    begin
+                        r_tx_size <= s_cmd_decode_size;
+                        r_tx_en   <= 1'b1;
+                    end
+                    else
+                    begin
+                        r_rx_size <= s_cmd_decode_size;
+                        r_rx_en   <= 1'b1;
+                    end
+                end
+            end
+            else if (cfg_valid_i & ~cfg_rwn_i)
             begin
                 case (s_wr_addr)
+                `REG_CMD_SADDR:
+                    r_cmd_startaddr   <= cfg_data_i[L2_AWIDTH_NOAL-1:0];
+                `REG_CMD_SIZE:
+                    r_cmd_size        <= cfg_data_i[TRANS_SIZE-1:0];
+                `REG_CMD_CFG:
+                begin
+                    r_cmd_clr         <= cfg_data_i[5];
+                    r_cmd_en          <= cfg_data_i[4];
+                    r_cmd_continuous  <= cfg_data_i[0];
+                end
                 `REG_RX_SADDR:
                     r_rx_startaddr   <= cfg_data_i[L2_AWIDTH_NOAL-1:0];
                 `REG_RX_SIZE:
@@ -176,6 +258,12 @@ module udma_i2c_reg_if #(
     begin
         cfg_data_o = 32'h0;
         case (s_rd_addr)
+        `REG_CMD_SADDR:
+            cfg_data_o = cfg_cmd_curr_addr_i;
+        `REG_CMD_SIZE:
+            cfg_data_o[TRANS_SIZE-1:0] = cfg_cmd_bytes_left_i;
+        `REG_CMD_CFG:
+            cfg_data_o = {26'h0,cfg_cmd_pending_i,cfg_cmd_en_i,1'b0,2'b10,r_cmd_continuous};
         `REG_RX_SADDR:
             cfg_data_o = cfg_rx_curr_addr_i;
         `REG_RX_SIZE:

--- a/rtl/udma_i2c_reg_if.sv
+++ b/rtl/udma_i2c_reg_if.sv
@@ -109,23 +109,23 @@ module udma_i2c_reg_if #(
             r_rx_startaddr  <=  'h0;
             r_rx_size       <=  'h0;
             r_rx_continuous <=  'h0;
-            r_rx_en          =  'h0;
-            r_rx_clr         =  'h0;
+            r_rx_en         <=  'h0;
+            r_rx_clr        <=  'h0;
             r_tx_startaddr  <=  'h0;
             r_tx_size       <=  'h0;
             r_tx_continuous <=  'h0;
-            r_tx_en          =  'h0;
-            r_tx_clr         =  'h0;
+            r_tx_en         <=  'h0;
+            r_tx_clr        <=  'h0;
             r_do_rst        <= 1'b0;
             r_busy          <= 1'b0;
             r_al            <= 1'b0;
         end
         else
         begin
-            r_rx_en         =  'h0;
-            r_rx_clr        =  'h0;
-            r_tx_en         =  'h0;
-            r_tx_clr        =  'h0;
+            r_rx_en        <=  'h0;
+            r_rx_clr       <=  'h0;
+            r_tx_en        <=  'h0;
+            r_tx_clr       <=  'h0;
 
             if (cfg_valid_i & ~cfg_rwn_i)
             begin
@@ -136,8 +136,8 @@ module udma_i2c_reg_if #(
                     r_rx_size        <= cfg_data_i[TRANS_SIZE-1:0];
                 `REG_RX_CFG:
                 begin
-                    r_rx_clr          = cfg_data_i[5];
-                    r_rx_en           = cfg_data_i[4];
+                    r_rx_clr         <= cfg_data_i[5];
+                    r_rx_en          <= cfg_data_i[4];
                     r_rx_continuous  <= cfg_data_i[0];
                 end
                 `REG_TX_SADDR:
@@ -146,8 +146,8 @@ module udma_i2c_reg_if #(
                     r_tx_size        <= cfg_data_i[TRANS_SIZE-1:0];
                 `REG_TX_CFG:
                 begin
-                    r_tx_clr          = cfg_data_i[5];
-                    r_tx_en           = cfg_data_i[4];
+                    r_tx_clr         <= cfg_data_i[5];
+                    r_tx_en          <= cfg_data_i[4];
                     r_tx_continuous  <= cfg_data_i[0];
                 end
                 `REG_SETUP:

--- a/rtl/udma_i2c_reg_if.sv
+++ b/rtl/udma_i2c_reg_if.sv
@@ -22,20 +22,7 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-// SPI Master Registers
-`define REG_RX_SADDR     5'b00000 //BASEADDR+0x00
-`define REG_RX_SIZE      5'b00001 //BASEADDR+0x04
-`define REG_RX_CFG       5'b00010 //BASEADDR+0x08
-`define REG_RX_INTCFG    5'b00011 //BASEADDR+0x0C
-
-`define REG_TX_SADDR     5'b00100 //BASEADDR+0x10
-`define REG_TX_SIZE      5'b00101 //BASEADDR+0x14
-`define REG_TX_CFG       5'b00110 //BASEADDR+0x18
-`define REG_TX_INTCFG    5'b00111 //BASEADDR+0x1C
-
-`define REG_STATUS       5'b01000 //BASEADDR+0x20
-`define REG_SETUP        5'b01001 //BASEADDR+0x24
-
+`include "udma_i2c_defines.sv"
 module udma_i2c_reg_if #(
     parameter L2_AWIDTH_NOAL = 12,
     parameter TRANS_SIZE     = 16

--- a/rtl/udma_i2c_top.sv
+++ b/rtl/udma_i2c_top.sv
@@ -8,24 +8,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-`define I2C_CMD_START   4'h0
-`define I2C_CMD_STOP    4'h2
-`define I2C_CMD_RD_ACK  4'h4
-`define I2C_CMD_RD_NACK 4'h6
-`define I2C_CMD_WR      4'h8
-`define I2C_CMD_WAIT    4'hA
-`define I2C_CMD_RPT     4'hC
-`define I2C_CMD_CFG     4'hE
-`define I2C_CMD_WAIT_EV 4'h1
-
-`define BUS_CMD_NONE  3'b000
-`define BUS_CMD_START 3'b001
-`define BUS_CMD_STOP  3'b010
-`define BUS_CMD_WRITE 3'b011
-`define BUS_CMD_READ  3'b100
-`define BUS_CMD_WAIT  3'b101
-
-
+`include "udma_i2c_defines.sv"
 module udma_i2c_top #(
     parameter L2_AWIDTH_NOAL = 12,
     parameter TRANS_SIZE     = 16


### PR DESCRIPTION
Adding an uDMA_qspi like command channel.
In particular, this allows using only one channel for reads instead of setting rx+tx.
This also makes uDMA accesses more uniform across spi and i2c.

At the same time, commands are extended to 32 bits, easing argument passing for programmer and squashing a few states in FSM. 