### PR TITLE
Improve ack/err/busy/alert control

### DIFF
--- a/rtl/udma_i2c_defines.sv
+++ b/rtl/udma_i2c_defines.sv
@@ -16,6 +16,7 @@
 
 `define REG_STATUS       5'b01100 //BASEADDR+0x30
 `define REG_SETUP        5'b01101 //BASEADDR+0x34
+`define REG_ACK          5'b01110 //BASEADDR+0X38
 
 // uDMA I2C commands
 `define I2C_CMD_START     4'b0000  //  0x0


### PR DESCRIPTION
## Overview

* Wire `busy`, `alert` and `err` signals (they were unconnected)
* `nack` is kept high until the register is read, not for a single clock cycle only
* Same applies for `busy` and `alert` to keep their values until further read, and avoid loosing their content after 1 cycle
* These features allow a slave device to properly signal when the i2c master write returned a NACK (not aknowledgment of the transaction) for whatever reason 

